### PR TITLE
v0.0.4-alpha

### DIFF
--- a/Get-WLANs/get-wlans.psd1
+++ b/Get-WLANs/get-wlans.psd1
@@ -4,7 +4,7 @@
 @{
 
 RootModule = 'Get-WLANs.psm1'
-ModuleVersion = '0.0.3'
+ModuleVersion = '0.0.4'
 GUID = '997ccb39-6038-4f66-a015-c39cf95c438f'
 Author = 'Josh Schmelzle'
 Copyright = '(c) Josh Schmelzle. All rights reserved.'


### PR DESCRIPTION
- If multiple NICs are present only one is used - previously all NICs would be used
- Use `-interface` param to specify a different one
- Added capability and IE size props
- Removed code that doesn't do anything
- Changed wait time from 3 seconds to 4 seconds - this should be replaced in the future with a callback notifying when scan results are ready to get